### PR TITLE
Reorganize the API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - pip install tox
 
 script:
-  - tox -e $TOX_ENV
+  - tox -e $TOX_ENV -v
 
 before_cache:
   - rm -rf $HOME/.cache/pip/log

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,11 @@ python:
   - "3.6"
   - "pypy"
 
-matrix:
-    include:
-      - python: 2.7
-        env: TOX_ENV=py27
-      - python: pypy
-        env: TOX_ENV=pypy
-      - python: 3.6
-        env: TOX_ENV=flake8
-
 install:
-  - pip install tox
+  - pip install tox-travis
 
 script:
-  - tox -e $TOX_ENV -v
+  - tox -v
 
 before_cache:
   - rm -rf $HOME/.cache/pip/log

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@
 
 sudo: false
 language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "pypy"
 
 matrix:
     include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,18 @@ environment:
     - PYTHON: "C:\\Python27"
       TOX_ENV: "py27"
 
+    - PYTHON: "C:\\Python33"
+      TOX_ENV: "py33"
+
+    - PYTHON: "C:\\Python34"
+      TOX_ENV: "py34"
+
+    - PYTHON: "C:\\Python35"
+      TOX_ENV: "py35"
+
+    - PYTHON: "C:\\Python36"
+      TOX_ENV: "py36"
+
 init:
   - "%PYTHON%/python -V"
   - "%PYTHON%/python -c \"import struct;print( 8 * struct.calcsize(\'P\'))\""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  - "%PYTHON%/Scripts/tox -e %TOX_ENV%"
+  - "%PYTHON%/Scripts/tox -e %TOX_ENV% -v"
 
 after_test:
   - "%PYTHON%/python setup.py bdist_wheel"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  - "%PYTHON%/Scripts/tox -e %TOX_ENV% -v"
+  - "%PYTHON%/Scripts/tox -v -e %TOX_ENV%"
 
 after_test:
   - "%PYTHON%/python setup.py bdist_wheel"

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -8,7 +8,7 @@ _true_socket = socket.socket
 
 class SocketBlockedError(RuntimeError):
     def __init__(self, *args, **kwargs):
-        super().__init__("A test tried to use socket.socket.")
+        super(SocketBlockedError, self).__init__("A test tried to use socket.socket.")
 
 
 def pytest_addoption(parser):

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -1,45 +1,46 @@
 # -*- coding: utf-8 -*-
 import socket
-import sys
 
 import pytest
 
-_module = sys.modules[__name__]
+_true_socket = socket.socket
 
 
-def pytest_runtest_setup():
-    """ disable the internet. test-cases can explicitly re-enable """
+@pytest.fixture(autouse=True)
+def _socket_marker(request):
+    if request.node.get_marker('disable_socket'):
+        request.getfixturevalue('socket_disabled')
+    if request.node.get_marker('enable_socket'):
+        request.getfixturevalue('socket_enabled')
+
+
+@pytest.fixture
+def socket_disabled():
+    """ disable socket.socket for duration of this test function """
     disable_socket()
-
-
-@pytest.fixture(scope='function')
-def socket_enabled(request):
-    """ re-enable socket.socket for duration of this test function """
+    yield
     enable_socket()
-    request.addfinalizer(disable_socket)
+
+
+@pytest.fixture
+def socket_enabled():
+    """ enable socket.socket for duration of this test function """
+    enable_socket()
+    yield
+    disable_socket()
 
 
 def disable_socket():
     """ disable socket.socket to disable the Internet. useful in testing.
     """
-    setattr(_module, u'_socket_disabled', True)
 
     def guarded(*args, **kwargs):
-        if getattr(_module, u'_socket_disabled', False):
-            raise RuntimeError(
-                u"A test tried to use socket.socket without explicitly un-blocking it.")
-        else:
-            # SocketType is a valid, public alias of socket.socket,
-            # we use it here to avoid namespace collisions
-            return socket.SocketType(*args, **kwargs)
+        raise RuntimeError("A test tried to use socket.socket.")
 
     socket.socket = guarded
-
-    print(u'[!] socket.socket is now blocked. The network should be inaccessible.')
 
 
 def enable_socket():
     """ re-enable socket.socket to enable the Internet. useful in testing.
     """
-    setattr(_module, u'_socket_disabled', False)
-    print(u'[!] socket.socket is UN-blocked, and the network can be accessed.')
+    socket.socket = _true_socket

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description='Pytest Plugin to disable socket calls during tests',
     long_description=read('README.rst'),
     py_modules=['pytest_socket'],
-    install_requires=['pytest>=3.1.1'],
+    install_requires=['pytest>=3.0.0'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Pytest',

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -113,7 +113,7 @@ def test_urllib_succeeds_by_default(testdir):
             from urllib2 import urlopen
 
         def test_disable_socket_urllib():
-            assert urlopen('https://httpbin.org/get').getcode() == 200
+            assert urlopen('http://httpbin.org/get').getcode() == 200
     """)
     result = testdir.runpytest("--verbose")
     result.assert_outcomes(1, 0, 0)
@@ -130,7 +130,7 @@ def test_enabled_urllib_succeeds(testdir):
 
         @pytest.mark.enable_socket
         def test_disable_socket_urllib():
-            assert urlopen('https://httpbin.org/get').getcode() == 200
+            assert urlopen('http://httpbin.org/get').getcode() == 200
     """)
     result = testdir.runpytest("--verbose", "--disable-socket")
     result.assert_outcomes(0, 0, 1)
@@ -147,7 +147,7 @@ def test_disabled_urllib_fails(testdir):
 
         @pytest.mark.disable_socket
         def test_disable_socket_urllib():
-            assert urlopen('https://httpbin.org/get').getcode() == 200
+            assert urlopen('http://httpbin.org/get').getcode() == 200
     """)
     result = testdir.runpytest("--verbose")
     result.assert_outcomes(0, 0, 1)

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from pytest_socket import enable_socket
 
 
@@ -20,7 +21,7 @@ def assert_socket_blocked(result):
 def test_socket_enabled_by_default(testdir):
     testdir.makepyfile("""
         import socket
-        
+
         def test_socket():
             socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     """)
@@ -80,7 +81,7 @@ def test_disable_socket_marker(testdir):
     testdir.makepyfile("""
         import pytest
         import socket
-        
+
         @pytest.mark.disable_socket
         def test_socket():
             socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -94,7 +95,7 @@ def test_enable_socket_marker(testdir):
     testdir.makepyfile("""
         import pytest
         import socket
-        
+
         @pytest.mark.enable_socket
         def test_socket():
             socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -110,7 +111,7 @@ def test_urllib_succeeds_by_default(testdir):
             from urllib.request import urlopen
         except ImportError:
             from urllib2 import urlopen
-        
+
         def test_disable_socket_urllib():
             assert urlopen('https://httpbin.org/get').getcode() == 200
     """)
@@ -158,18 +159,18 @@ def test_double_call_does_nothing(testdir):
         import pytest
         import pytest_socket
         import socket
-        
+
         def test_double_enabled():
             pytest_socket.enable_socket()
             pytest_socket.enable_socket()
             socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            
+
         def test_double_disabled():
             pytest_socket.disable_socket()
             pytest_socket.disable_socket()
             with pytest.raises(pytest_socket.SocketBlockedError):
                 socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            
+
         def test_disable_enable():
             pytest_socket.disable_socket()
             pytest_socket.enable_socket()

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -1,11 +1,33 @@
 # -*- coding: utf-8 -*-
 import pytest
+from pytest_socket import enable_socket
+
+
+@pytest.fixture(autouse=True)
+def reenable_socket():
+    # The tests can leave the socket disabled in the global scope.
+    # Fix that by automatically re-enabling it after each test
+    yield
+    enable_socket()
 
 
 def assert_socket_blocked(result):
     result.stdout.fnmatch_lines("""
         *SocketBlockedError: A test tried to use socket.socket.*
     """)
+
+
+def test_socket_enabled_by_default(testdir):
+    testdir.makepyfile("""
+        import socket
+        
+        def test_socket():
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    """)
+    result = testdir.runpytest("--verbose")
+    result.assert_outcomes(1, 0, 0)
+    with pytest.raises(Exception):
+        assert_socket_blocked(result)
 
 
 def test_global_disable_via_fixture(testdir):
@@ -93,8 +115,7 @@ def test_urllib_succeeds_by_default(testdir):
             assert urlopen('https://httpbin.org/get').getcode() == 200
     """)
     result = testdir.runpytest("--verbose")
-    result.assert_outcomes(0, 0, 1)
-    assert_socket_blocked(result)
+    result.assert_outcomes(1, 0, 0)
 
 
 def test_enabled_urllib_succeeds(testdir):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py27,pypy,flake8
+envlist = py27,py33,py34,py35,py36,pypy,flake8
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
I like this plugin a lot but the by-default blocking really hinders its usefulness. If you install it in a global environment then all py.test runs will be unintentionally affected. I suggest removing that default behavior, which this PR does.

I also introduced the following changes.
* Add `@pytest.mark.disable_socket` and `@pytest.mark.enable_socket` to conveniently mark tests without importing the package.
* Add `socket_disabled` and `socket_enabled` fixtures.
* Add `--disable-socket` CLI option. This can be also used to easily disable the socket by default by adding it to `pytest.ini`.
* Create a separate `SocketBlockedError` exception that is easier to check against in tests, if necessary.
* Simplify the socket blocking code.
* Remove any printed messages. This is just unnecessary noise, IMHO.
* Add Python 3 compatibility in tests and test all Python versions in the CI.