### PR TITLE
Change the inherited exception class in tests

### DIFF
--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -27,7 +27,7 @@ def test_socket_enabled_by_default(testdir):
     """)
     result = testdir.runpytest("--verbose")
     result.assert_outcomes(1, 0, 0)
-    with pytest.raises(Exception):
+    with pytest.raises(BaseException):
         assert_socket_blocked(result)
 
 
@@ -188,7 +188,7 @@ def test_double_call_does_nothing(testdir):
     """)
     result = testdir.runpytest("--verbose")
     result.assert_outcomes(3, 0, 0)
-    with pytest.raises(Exception):
+    with pytest.raises(BaseException):
         assert_socket_blocked(result)
 
 
@@ -200,7 +200,7 @@ def test_socket_enabled_fixture(testdir, socket_enabled):
     """)
     result = testdir.runpytest("--verbose")
     result.assert_outcomes(1, 0, 0)
-    with pytest.raises(Exception):
+    with pytest.raises(BaseException):
         assert_socket_blocked(result)
 
 


### PR DESCRIPTION
As of pytest 3.2.0, the internal outcome class no longer inherits from Exception, rather from BaseException.

This was reported in pytest-dev/pytest#580 and changed in pytest-dev/pytest#2490

Signed-off-by: Mike Fiedler <miketheman@gmail.com>