### PR TITLE
Replace node.get_marker with node.get_closest_marker

### DIFF
--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -39,9 +39,9 @@ def pytest_addoption(parser):
 
 @pytest.fixture(autouse=True)
 def _socket_marker(request):
-    if request.node.get_marker('disable_socket'):
+    if request.node.get_closest_marker('disable_socket'):
         request.getfixturevalue('socket_disabled')
-    if request.node.get_marker('enable_socket'):
+    if request.node.get_closest_marker('enable_socket'):
         request.getfixturevalue('socket_enabled')
 
     if request.config.getoption('--disable-socket'):


### PR DESCRIPTION
`node.get_marker` was removed in pytest 4.1. The pytest changelog suggests
using `node.get_closest_marker` as a replacement.

Fixes #16 