### PR TITLE
Fix for pytest.mark.enable_socket

### DIFF
--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -40,13 +40,16 @@ def pytest_addoption(parser):
 
 @pytest.fixture(autouse=True)
 def _socket_marker(request):
+    """ The last option to set the fixture wins priority.
+    The expected behavior is that higher granularity options should
+    override lower granularity options.
+    """
+    if request.config.getoption('--disable-socket'):
+        request.getfixturevalue('socket_disabled')
     if request.node.get_closest_marker('disable_socket'):
         request.getfixturevalue('socket_disabled')
     if request.node.get_closest_marker('enable_socket'):
         request.getfixturevalue('socket_enabled')
-
-    if request.config.getoption('--disable-socket'):
-        request.getfixturevalue('socket_disabled')
 
 
 @pytest.fixture

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -111,8 +111,9 @@ def test_enable_socket_marker(testdir):
             socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     """)
     result = testdir.runpytest("--verbose", "--disable-socket")
-    result.assert_outcomes(0, 0, 1)
-    assert_socket_blocked(result)
+    result.assert_outcomes(1, 0, 0)
+    with pytest.raises(BaseException):
+        assert_socket_blocked(result)
 
 
 def test_urllib_succeeds_by_default(testdir):
@@ -143,8 +144,9 @@ def test_enabled_urllib_succeeds(testdir):
             assert urlopen('http://httpbin.org/get').getcode() == 200
     """)
     result = testdir.runpytest("--verbose", "--disable-socket")
-    result.assert_outcomes(0, 0, 1)
-    assert_socket_blocked(result)
+    result.assert_outcomes(1, 0, 0)
+    with pytest.raises(BaseException):
+        assert_socket_blocked(result)
 
 
 def test_disabled_urllib_fails(testdir):


### PR DESCRIPTION
A few tests for enabled sockets had inverted success criteria.
Issue #15 is resolved by prioritizing the pytest markers over the CLI config.