### PR TITLE
test: extend match to account for wildcard text

### DIFF
--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -67,7 +67,7 @@ def test_help_message(testdir):
     )
     result.stdout.fnmatch_lines([
         'socket:',
-        '*--disable-socket*Disable socket.socket by default to block network'
+        '*--disable-socket*Disable socket.socket by default to block network*'
     ])
 
 


### PR DESCRIPTION
For some reason, the test in pytest 5.x has stopped working with the
existing test case - which has extra text beyond this string, so apply a
wildcard (as probably should have been done originally).

Signed-off-by: Mike Fiedler <miketheman@gmail.com>