### PR TITLE
Upgrade to the latest virtualenv in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ init:
 
 install:
   - "%PYTHON%/Scripts/easy_install -U pip"
+  - "%PYTHON%/Scripts/pip install -U virtualenv"
   - "%PYTHON%/Scripts/pip install tox"
   - "%PYTHON%/Scripts/pip install wheel"
 


### PR DESCRIPTION
### The problem

The problem is tox uses an old `virtualenv` from site-packages, see the [log](https://ci.appveyor.com/project/miketheman/pytest-socket/builds/27806599/job/rc5qa94e9b7nlcgg#L48) in the last build:
```
48 Requirement already satisfied: virtualenv>=14.0.0 in c:\python27\lib\site-packages (from tox) (15.0.1)
```

and this virtualenv has installed `pip==8.1.1` inside, see the [warning](https://ci.appveyor.com/project/miketheman/pytest-socket/builds/27806599/job/rc5qa94e9b7nlcgg#L110):

```
110 You are using pip version 8.1.1, however version 19.2.3 is available.
111 You should consider upgrading via the 'python -m pip install --upgrade pip' command.
```

which can't handle the enviroment markers ([PEP 496](https://www.python.org/dev/peps/pep-0496/)) properly. The support of environment markers was introduced/fixed in `pip==8.1.2` (see the release [notes](https://pip.pypa.io/en/stable/news/#id229)), that's why pip  is complaining:

```
109 RequirementParseError: Expected ',' or end-of-list in pathlib2>=2.2.0;python_version<"3.6" at ;python_version<"3.6"
```

### Solution

The solution is to upgrade virtualenv to the latest version, which has a fresh pip.

### Additional context

I presume the issue has appeared since pytest dropped the python 2 support and started to use env markers to support 4.X (python2/3) and 5.X (python 3 only) versions.

Fixes #32.