### PR TITLE
fix: correctly set fixture when using markers

### DIFF
--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -38,13 +38,20 @@ def pytest_addoption(parser):
 
 @pytest.fixture(autouse=True)
 def _socket_marker(request):
+    """
+    Create an automatically-used fixture that every test function will load.
+
+    The last option to set the fixture wins priority.
+    The expected behavior is that higher granularity options should override
+    lower granularity options.
+    """
+    if request.config.getoption('--disable-socket'):
+        request.getfixturevalue('socket_disabled')
+
     if request.node.get_closest_marker('disable_socket'):
         request.getfixturevalue('socket_disabled')
     if request.node.get_closest_marker('enable_socket'):
         request.getfixturevalue('socket_enabled')
-
-    if request.config.getoption('--disable-socket'):
-        request.getfixturevalue('socket_disabled')
 
 
 @pytest.fixture

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -101,7 +101,9 @@ def test_enable_socket_marker(testdir):
             socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     """)
     result = testdir.runpytest("--verbose", "--disable-socket")
-    assert_socket_blocked(result)
+    result.assert_outcomes(1, 0, 0)
+    with pytest.raises(BaseException):
+        assert_socket_blocked(result)
 
 
 def test_urllib_succeeds_by_default(testdir):
@@ -116,6 +118,8 @@ def test_urllib_succeeds_by_default(testdir):
     """)
     result = testdir.runpytest("--verbose")
     result.assert_outcomes(1, 0, 0)
+    with pytest.raises(BaseException):
+        assert_socket_blocked(result)
 
 
 def test_enabled_urllib_succeeds(testdir):
@@ -132,7 +136,9 @@ def test_enabled_urllib_succeeds(testdir):
             assert urlopen('http://httpbin.org/get').getcode() == 200
     """)
     result = testdir.runpytest("--verbose", "--disable-socket")
-    assert_socket_blocked(result)
+    result.assert_outcomes(1, 0, 0)
+    with pytest.raises(BaseException):
+        assert_socket_blocked(result)
 
 
 def test_disabled_urllib_fails(testdir):


### PR DESCRIPTION
As reported in a couple of issues, the usage of markers (not fixtures)
was misbehaving, as the order in which the `_socket_marker` evaluation
was occurring left the command-line option disabled.

Fixes #15
Closes #28

Co-authored-by: Calvin Behling <calvin.behling@gmail.com>
Signed-off-by: Albert Tugushev <albert@tugushev.ru>
Signed-off-by: Matt Callaghan <mcallaghan-bsm@users.noreply.github.com>
Signed-off-by: Mike Fiedler <miketheman@gmail.com>