### PR TITLE
Avoid changing the type of `socket.socket` to function.

### DIFF
--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -74,10 +74,12 @@ def disable_socket():
     """ disable socket.socket to disable the Internet. useful in testing.
     """
 
-    def guarded(*args, **kwargs):
-        raise SocketBlockedError()
+    class GuardedSocket(socket.socket):
+        """ socket guard to disable socket creation (from pytest-socket) """
+        def __new__(cls, *args, **kwargs):
+            raise SocketBlockedError()
 
-    socket.socket = guarded
+    socket.socket = GuardedSocket
 
 
 def enable_socket():

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -210,3 +210,21 @@ def test_mix_and_match(testdir, socket_enabled):
     """)
     result = testdir.runpytest("--verbose", "--disable-socket")
     result.assert_outcomes(1, 0, 2)
+
+
+def test_socket_subclass_is_still_blocked(testdir):
+    testdir.makepyfile("""
+        import pytest
+        import pytest_socket
+        import socket
+
+        @pytest.mark.disable_socket
+        def test_subclass_is_still_blocked():
+
+            class MySocket(socket.socket):
+                pass
+
+            MySocket(socket.AF_INET, socket.SOCK_STREAM)
+    """)
+    result = testdir.runpytest("--verbose")
+    assert_socket_blocked(result)


### PR DESCRIPTION
Thanks for providing this really useful extension to `pytest`.

Recently, using `pytest-socket` interfered with the `docker` package, which started subclassing `socket.socket`; and obviously failed since this package changes it to be a function rather than a class.

In this patch, I've replaced the socket guard with a class deriving from `socket.socket`, but overriding the `__new__` method such that any attempt to instantiate it results in the same error as before.