### PR TITLE
chore: remove support for python 3.5

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,7 +19,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Testing",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -28,7 +27,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.6"
 pytest = ">=3.6.3"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Support for Python 3.5 ended 13 September 2020.

Tools like `poetry` and `pip` will be removing their support soon, so
before their removal hits us, remove the support from the plugin.

Resolved #51

Signed-off-by: Mike Fiedler <miketheman@gmail.com>