### PR TITLE
test: add testing for some async frameworks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ pytest = "^6.0"
 pytest-cov = "^2.8.1"
 pytest-httpbin = "^1.0"
 pytest-flake8 = "^1.0.4"
+asynctest = "^0.13.0"
+starlette = "^0.14.2"
 
 [tool.poetry.plugins.pytest11]
 socket = 'pytest_socket'

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,56 @@
+import socket
+
+import pytest
+
+
+unix_sockets_only = pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"),
+    reason="Skip any platform that does not support AF_UNIX",
+)
+
+
+@unix_sockets_only
+def test_asynctest(testdir):
+    testdir.makepyfile("""
+        import asynctest
+
+
+        class AnExampleWithTestCaseAndCoroutines(asynctest.TestCase):
+            async def a_coroutine(self):
+                return "I worked"
+
+            async def test_that_a_coroutine_runs(self):
+                self.assertIn("worked", await self.a_coroutine())
+
+            async def test_inet_is_blocked(self):
+                socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    """)
+    result = testdir.runpytest("--verbose", "--disable-socket", "--allow-unix-socket")
+    result.assert_outcomes(passed=1, skipped=0, failed=1)
+
+
+@unix_sockets_only
+def test_starlette(testdir):
+    testdir.makepyfile("""
+        from pytest_socket import disable_socket
+        from starlette.responses import HTMLResponse
+        from starlette.testclient import TestClient
+
+
+        def pytest_runtest_setup():
+            disable_socket()
+
+
+        async def app(scope, receive, send):
+            assert scope['type'] == 'http'
+            response = HTMLResponse('<html><body>Hello, world!</body></html>')
+            await response(scope, receive, send)
+
+
+        def test_app():
+            client = TestClient(app)
+            response = client.get('/')
+            assert response.status_code == 200
+    """)
+    result = testdir.runpytest("--verbose", "--disable-socket", "--allow-unix-socket")
+    result.assert_outcomes(passed=1, skipped=0, failed=0)


### PR DESCRIPTION
While the basics of asyncio ought to be covered by enabling unix
sockets in #54, I thought it might be nice to add some explicit asyncio
tests to ensure that we don't hit any framework-specific regressions.
I had written these locally when testing the changes anyhow.

Refs: #6
Refs: #47

Signed-off-by: Mike Fiedler <miketheman@gmail.com>