### PR TITLE
Give socket_allow_hosts the ability to handle AF_UNIX sockets

### DIFF
--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -114,13 +114,13 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
-    host_mark_restrictions = item.get_closest_marker('allow_hosts')
-    host_cli_restrictions = item.config.getoption('--allow-hosts')
+    mark_restrictions = item.get_closest_marker('allow_hosts')
+    cli_restrictions = item.config.getoption('--allow-hosts')
     hosts = None
-    if host_mark_restrictions:
-        hosts = host_mark_restrictions.args[0]
-    elif host_cli_restrictions:
-        hosts = host_cli_restrictions
+    if mark_restrictions:
+        hosts = mark_restrictions.args[0]
+    elif cli_restrictions:
+        hosts = cli_restrictions
 
     allow_unix_socket = False
     if item.get_closest_marker('allow_unix_socket') or item.config.getoption('--allow-unix-socket'):

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -54,3 +54,66 @@ def test_starlette(testdir):
     """)
     result = testdir.runpytest("--verbose", "--disable-socket", "--allow-unix-socket")
     result.assert_outcomes(passed=1, skipped=0, failed=0)
+
+
+@unix_sockets_only
+def test_allow_unix_socket_connections(testdir):
+    # Check that the --allow-unix-socket cli arg works for socket.connect
+    testdir.makepyfile("""
+        import pytest
+        import socket
+        import multiprocessing
+
+        def test_pass_with_cli_arg():
+            manager = multiprocessing.Manager()
+            lst = manager.list([1, 2, 3])
+    """)
+    result = testdir.runpytest("--verbose", "--allow-hosts=1.2.3.4", "--allow-unix-socket")
+    result.assert_outcomes(passed=1, skipped=0, failed=0)
+
+    # Check that the allow_unix_socket mark works for socket.connect
+    testdir.makepyfile("""
+        import pytest
+        import socket
+        import multiprocessing
+
+        @pytest.mark.allow_unix_socket
+        def test_pass_with_pytest_mark():
+            manager = multiprocessing.Manager()
+            lst = manager.list([1, 2, 3])
+
+        def test_fail_without_pytest_mark():
+            manager = multiprocessing.Manager()
+            lst = manager.list([1, 2, 3])
+    """)
+    result = testdir.runpytest("--verbose", "--allow-hosts=1.2.3.4")
+    result.assert_outcomes(passed=1, skipped=0, failed=1)
+    result.stdout.fnmatch_lines('*A test tried to use socket.socket.connect() with host*')
+
+
+@unix_sockets_only
+def test_unix_socket_connections_name_specified(testdir, tmp_path):
+
+    unix_socket_file_path = tmp_path / "test_unix_socket.s"
+
+    # Check that the --allow-hosts cli arg works for socket.connect of AF_UNIX socket
+    testdir.makepyfile("""
+        import pytest
+        import socket
+
+        def test_pass_with_host_allowed():
+            test_socket_server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            test_socket_server.bind("{0}")
+            test_socket_server.listen()
+
+            test_socket_client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            test_socket_client.connect("{0}")
+
+        def test_fail_with_bad_host():
+            test_socket_client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            test_socket_client.connect("/tmp/fake_socket_name.s")
+
+    """.format(unix_socket_file_path))
+    result = testdir.runpytest("--verbose", "--allow-hosts={0}".format(unix_socket_file_path))
+    result.assert_outcomes(passed=1, skipped=0, failed=1)
+    result.stdout.fnmatch_lines('*A test tried to use socket.socket.connect() with host "/tmp/fake_socket_name.s"*')


### PR DESCRIPTION
Fixes #70 

socket_allow_hosts now allows any AF_UNIX socket connection if --allow-unix-socket is specified on the CLI or if allow_unix_socket is used as a pytest mark. It also works for AF_UNIX sockets with known socket (file) names if you pass the correct name in --allow-hosts.