### PR TITLE
feat: support cidr blocks in --allow-hosts

### DIFF
--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -162,10 +162,11 @@ def socket_allow_hosts(allowed=None):
 
 
 def host_in_cidr_block(host, cidrs):
-    if host and len(cidrs) > 0:
-        for cidr in cidrs:
-            if address_in_network(host, cidr):
-                return True
+    if not host or len(cidrs) == 0:
+        return False
+    for cidr in cidrs:
+        if address_in_network(host, cidr):
+            return True
     return False
 
 

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -154,13 +154,19 @@ def socket_allow_hosts(allowed=None):
         host = host_from_connect_args(args)
         if host and host in allowed:
             return _true_connect(inst, *args)
-        elif host and len(cidrs) > 0:
-            for cidr in cidrs:
-                if address_in_network(host, cidr):
-                    return _true_connect(inst, *args)
+        elif host_in_cidr_block(host, cidrs):
+            return _true_connect(inst, *args)
         raise SocketConnectBlockedError(allowed, host)
 
     socket.socket.connect = guarded_connect
+
+
+def host_in_cidr_block(host, cidrs):
+    if host and len(cidrs) > 0:
+        for cidr in cidrs:
+            if address_in_network(host, cidr):
+                return True
+    return False
 
 
 def is_valid_cidr(network):

--- a/tests/test_restrict_hosts.py
+++ b/tests/test_restrict_hosts.py
@@ -241,3 +241,38 @@ def test_conflicting_cli_vs_marks(testdir, httpbin):
     result.assert_outcomes(1, 0, 2)
     assert_host_blocked(result, '2.2.2.2')
     assert_host_blocked(result, test_url.hostname)
+
+
+def test_cidr_allow(testdir, httpbin):
+    test_url = urlparse(httpbin.url)
+    testdir.makepyfile(
+        """
+        import pytest
+        import socket
+
+        @pytest.mark.allow_hosts('127.0.0.0/8')
+        def test_pass():
+            socket.socket().connect(('{0}', {1}))
+
+        @pytest.mark.allow_hosts('127.0.0.0/16')
+        def test_pass_2():
+            socket.socket().connect(('{0}', {1}))
+
+        def test_fail():
+            socket.socket().connect(('2.2.2.2', {1}))
+
+        def test_fail_2():
+            socket.socket().connect(('192.168.1.10', {1}))
+
+        @pytest.mark.allow_hosts('172.20.0.0/16')
+        def test_fail_3():
+            socket.socket().connect(('{0}', {1}))
+    """.format(
+            test_url.hostname, test_url.port
+        )
+    )
+    result = testdir.runpytest("--verbose", "--allow-hosts=1.2.3.4")
+    result.assert_outcomes(2, 0, 3)
+    assert_host_blocked(result, "2.2.2.2")
+    assert_host_blocked(result, "192.168.1.10")
+    assert_host_blocked(result, test_url.hostname)


### PR DESCRIPTION
This feature allows `--allow-hosts` to support CIDR blocks. This is useful inside Docker since different services can get any range of IPs (typically on 172.17.0.0/16 or 172.20.0.0/16) and pytest-socket doesn't support hostnames.

I can also add hostname support if we think that is useful.