### PR TITLE
Handle `family` passed as keyword argument

### DIFF
--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -86,7 +86,7 @@ def disable_socket(allow_unix_socket=False):
         """ socket guard to disable socket creation (from pytest-socket) """
         def __new__(cls, family=-1, type=-1, proto=-1, fileno=None):
             try:
-               is_unix_socket = family == socket.AF_UNIX
+                is_unix_socket = family == socket.AF_UNIX
             except AttributeError:
                 # AF_UNIX not supported on Windows https://bugs.python.org/issue33408
                 is_unix_socket = False

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -86,8 +86,11 @@ def disable_socket(allow_unix_socket=False):
         """ socket guard to disable socket creation (from pytest-socket) """
         def __new__(cls, *args, **kwargs):
             try:
-                is_unix_socket = args[0] == socket.AF_UNIX
-            except (AttributeError, IndexError):
+                if len(args) > 0:
+                    is_unix_socket = args[0] == socket.AF_UNIX
+                else:
+                    is_unix_socket = kwargs.get("family") == socket.AF_UNIX
+            except AttributeError, IndexError):
                 # AF_UNIX not supported on Windows https://bugs.python.org/issue33408
                 is_unix_socket = False
 

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -84,18 +84,15 @@ def disable_socket(allow_unix_socket=False):
 
     class GuardedSocket(socket.socket):
         """ socket guard to disable socket creation (from pytest-socket) """
-        def __new__(cls, *args, **kwargs):
+        def __new__(cls, family=-1, type=-1, proto=-1, fileno=None):
             try:
-                if len(args) > 0:
-                    is_unix_socket = args[0] == socket.AF_UNIX
-                else:
-                    is_unix_socket = kwargs.get("family") == socket.AF_UNIX
-            except AttributeError, IndexError):
+               is_unix_socket = family == socket.AF_UNIX
+            except AttributeError:
                 # AF_UNIX not supported on Windows https://bugs.python.org/issue33408
                 is_unix_socket = False
 
             if is_unix_socket and allow_unix_socket:
-                return super().__new__(cls, *args, **kwargs)
+                return super().__new__(cls, family, type, proto, fileno)
 
             raise SocketBlockedError()
 

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -3,11 +3,27 @@ import pytest
 import socket
 
 
-PYFILE_SOCKET_USED_IN_TEST = """
+PYFILE_SOCKET_USED_IN_TEST_ARGS = """
         import socket
 
         def test_socket():
             socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    """
+
+
+PYFILE_SOCKET_USED_IN_TEST_KWARGS = """
+        import socket
+
+        def test_socket():
+            socket.socket(family=socket.AF_INET, type=socket.SOCK_STREAM)
+    """
+
+
+PYFILE_SOCKET_NO_ARGS = """
+        import socket
+
+        def test_socket():
+            socket.socket()
     """
 
 
@@ -18,8 +34,16 @@ def assert_socket_blocked(result):
     """)
 
 
-def test_socket_enabled_by_default(testdir):
-    testdir.makepyfile(PYFILE_SOCKET_USED_IN_TEST)
+@pytest.mark.parametrize(
+    "pyfile",
+    [
+        PYFILE_SOCKET_USED_IN_TEST_ARGS,
+        PYFILE_SOCKET_USED_IN_TEST_KWARGS,
+        PYFILE_SOCKET_NO_ARGS
+    ]
+)
+def test_socket_enabled_by_default(testdir, pyfile):
+    testdir.makepyfile(pyfile)
     result = testdir.runpytest("--verbose")
     result.assert_outcomes(1, 0, 0)
     with pytest.raises(BaseException):
@@ -43,8 +67,16 @@ def test_global_disable_via_fixture(testdir):
     assert_socket_blocked(result)
 
 
-def test_global_disable_via_cli_flag(testdir):
-    testdir.makepyfile(PYFILE_SOCKET_USED_IN_TEST)
+@pytest.mark.parametrize(
+    "pyfile",
+    [
+        PYFILE_SOCKET_USED_IN_TEST_ARGS,
+        PYFILE_SOCKET_USED_IN_TEST_KWARGS,
+        PYFILE_SOCKET_NO_ARGS
+    ]
+)
+def test_global_disable_via_cli_flag(testdir, pyfile):
+    testdir.makepyfile(pyfile)
     result = testdir.runpytest("--verbose", "--disable-socket")
     assert_socket_blocked(result)
 
@@ -59,8 +91,16 @@ def test_help_message(testdir):
     ])
 
 
-def test_global_disable_via_config(testdir):
-    testdir.makepyfile(PYFILE_SOCKET_USED_IN_TEST)
+@pytest.mark.parametrize(
+    "pyfile",
+    [
+        PYFILE_SOCKET_USED_IN_TEST_ARGS,
+        PYFILE_SOCKET_USED_IN_TEST_KWARGS,
+        PYFILE_SOCKET_NO_ARGS
+    ]
+)
+def test_global_disable_via_config(testdir, pyfile):
+    testdir.makepyfile(pyfile)
     testdir.makeini("""
         [pytest]
         addopts = --disable-socket


### PR DESCRIPTION
Handle `family` passed as keyword argument to `socket` constructor