### PR TITLE
docs: Fix syntax for setup.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,21 @@ Run `pytest --disable-socket`, tests should fail on any access to `socket` or
 libraries using socket with a `SocketBlockedError`.
 
 To add this flag as the default behavior, add this section to your
-`pytest.ini` or `setup.cfg`:
+[`pytest.ini`](https://docs.pytest.org/en/6.2.x/customize.html#pytest-ini):
 
 ```ini
 [pytest]
 addopts = --disable-socket
 ```
 
-or update your `conftest.py` to include:
+or add this to your [`setup.cfg`](https://docs.pytest.org/en/6.2.x/customize.html#setup-cfg):
+
+```ini
+[tool:pytest]
+addopts = --disable-socket
+```
+
+or update your [`conftest.py`](https://docs.pytest.org/en/6.2.x/writing_plugins.html#conftest-py-plugins) to include:
 
 ```python
 from pytest_socket import disable_socket


### PR DESCRIPTION
If you follow the instructions in the README for adding pytest-socket to your setup.cfg, you get:

```
Failed: [pytest] section in setup.cfg files is no longer supported, changeto [tool:pytest] instead.
```

This PR adds the correct syntax for setup.cfg, and also links to the pytest documentation for the different configuration locations.