### PR TITLE
feat(allow_hosts): add support for hostname resolution

### DIFF
--- a/tests/test_restrict_hosts.py
+++ b/tests/test_restrict_hosts.py
@@ -106,6 +106,14 @@ def test_single_cli_arg_connect_enabled(assert_connect):
     assert_connect(True, cli_arg=localhost)
 
 
+def test_single_cli_arg_connect_enabled_hostname_resolved(assert_connect):
+    assert_connect(True, cli_arg="localhost")
+
+
+def test_single_cli_arg_connect_enabled_hostname_unresolvable(assert_connect):
+    assert_connect(False, cli_arg="unresolvable")
+
+
 def test_single_cli_arg_connect_unicode_enabled(assert_connect):
     assert_connect(True, cli_arg=localhost, code_template=connect_unicode_code_template)
 


### PR DESCRIPTION
Hey, thanks for the nice project.

### Scenario I'm attempting to solve:

- We have a service in our project we must connect to from a docker-composed application. 
- The hostname is stable but not the IP address.

Somewhat similar to #73

### What does this MR do

- Resolve `allowed` hostnames into IPs if possible and check if added exceptions are correct IPv4 addresses
- Strip strings added to the list to make sure `pytest --allow-hosts="172.18.0.2, 172.18.0.1"` works


### Questions

- no checks for IPv6 addresses was done, is it relevant to readd?

If type hinting is necessary or some documentation needs to be changed feel free to ask. 