### PR TITLE
chore(dev): update development commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ target/
 
 # poetry lock file - for libraries only
 poetry.lock
+
+# Installation tracking file
+.install.stamp

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: all clean poetry test dist testrelease release
 
+INSTALL_STAMP := .install.stamp
 POETRY := $(shell command -v poetry 2> /dev/null)
 
 all: test
@@ -7,18 +8,20 @@ all: test
 clean:
 	@find . -name \*.pyc -delete
 	@find . -name __pycache__ -delete
-	@rm -fr .cache/ .coverage .pytest_cache/ *.egg-info/ dist/ htmlcov/
+	@rm -fr $(INSTALL_STAMP) .cache/ .coverage .pytest_cache/ *.egg-info/ dist/ htmlcov/
 
-poetry.lock pytest_socket.egg-info/ :
+install: $(INSTALL_STAMP)
+$(INSTALL_STAMP): pyproject.toml poetry.lock
 ifndef POETRY
 	$(error "poetry is not available, please install it first.")
 endif
 	@poetry install
+	@touch $(INSTALL_STAMP)
 
-test: pytest_socket.egg-info/
+test: $(INSTALL_STAMP)
 	@poetry run pytest
 
-dist: clean poetry.lock
+dist: clean $(INSTALL_STAMP)
 	@poetry build
 
 testrelease: dist


### PR DESCRIPTION
The existing behavior relied on making the package "installable" and
having a resulting `.egg-info` file to inform Make on whether to run the
installation again.

Poetry removed that behavior, so now we set our own stamp file when
completing the installation.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>