### PR TITLE
test: move the reenable fixture to conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,12 @@
+import pytest
+from pytest_socket import enable_socket
+
 pytest_plugins = 'pytester'
+
+
+@pytest.fixture(autouse=True)
+def reenable_socket():
+    # The tests can leave the socket disabled in the global scope.
+    # Fix that by automatically re-enabling it after each test
+    yield
+    enable_socket()

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -2,8 +2,6 @@
 import pytest
 import socket
 
-from pytest_socket import enable_socket
-
 
 PYFILE_SOCKET_USED_IN_TEST = """
         import socket
@@ -11,14 +9,6 @@ PYFILE_SOCKET_USED_IN_TEST = """
         def test_socket():
             socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     """
-
-
-@pytest.fixture(autouse=True)
-def reenable_socket():
-    # The tests can leave the socket disabled in the global scope.
-    # Fix that by automatically re-enabling it after each test
-    yield
-    enable_socket()
 
 
 def assert_socket_blocked(result):


### PR DESCRIPTION
As we build out more test cases, we want to reenable the default
behavior after each test.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>