### PR TITLE
refactor/fix: move logic into setup phase and correct order

### DIFF
--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -114,6 +114,15 @@ def pytest_runtest_setup(item) -> None:
         return
 
     # Resolve `allow_hosts` behaviors.
+    hosts = _resolve_allow_hosts(item)
+
+    # Finally, check the global config and disable socket if needed.
+    if item.config.__socket_disabled and not hosts:
+        disable_socket(item.config.__socket_allow_unix_socket)
+
+
+def _resolve_allow_hosts(item):
+    """Resolve `allow_hosts` behaviors."""
     mark_restrictions = item.get_closest_marker('allow_hosts')
     cli_restrictions = item.config.__socket_allow_hosts
     hosts = None
@@ -122,10 +131,7 @@ def pytest_runtest_setup(item) -> None:
     elif cli_restrictions:
         hosts = cli_restrictions
     socket_allow_hosts(hosts)
-
-    # Finally, check the global config and disable socket if needed.
-    if item.config.__socket_disabled and not hosts:
-        disable_socket(item.config.__socket_allow_unix_socket)
+    return hosts
 
 
 def pytest_runtest_teardown():

--- a/tests/test_precedence.py
+++ b/tests/test_precedence.py
@@ -1,0 +1,160 @@
+"""Test module to express precedence tests between the different
+configuration combinations"""
+import pytest
+
+
+def assert_socket_blocked(result, passed=0, skipped=0, failed=1):
+    """Uses built in methods to test for common failure scenarios.
+    Usually we only test for a single failure,
+    but sometimes we want to test for multiple conditions,
+    so we can pass in the expected counts."""
+    result.assert_outcomes(passed=passed, skipped=skipped, failed=failed)
+    result.stdout.fnmatch_lines(
+        "*Socket*Blocked*Error: A test tried to use socket.socket.*"
+    )
+
+
+def test_disable_via_fixture(testdir):
+    testdir.makepyfile(
+        """
+        import socket
+
+        def test_socket(socket_disabled):
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        """
+    )
+    result = testdir.runpytest()
+    assert_socket_blocked(result)
+
+
+def test_disable_via_marker(testdir):
+    testdir.makepyfile(
+        """
+        import socket
+        import pytest
+
+        @pytest.mark.disable_socket
+        def test_socket():
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        """
+    )
+    result = testdir.runpytest()
+    assert_socket_blocked(result)
+
+
+def test_global_disable_via_cli_flag(testdir):
+    testdir.makepyfile(
+        """
+        import socket
+
+        def test_socket():
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        """
+    )
+    result = testdir.runpytest("--disable-socket")
+    assert_socket_blocked(result)
+
+
+def test_global_disable_via_config(testdir):
+    testdir.makepyfile(
+        """
+        import socket
+
+        def test_socket():
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        """
+    )
+    testdir.makeini(
+        """
+        [pytest]
+        addopts = --disable-socket
+        """
+    )
+    result = testdir.runpytest()
+    assert_socket_blocked(result)
+
+
+def test_enable_via_fixture(testdir):
+    testdir.makepyfile(
+        """
+        import socket
+
+        def test_socket(socket_enabled):
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        def test_socket_disabled():
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        """
+    )
+    result = testdir.runpytest("--disable-socket")
+    assert_socket_blocked(result, passed=1, failed=1)
+
+
+def test_enable_via_marker(testdir):
+    testdir.makepyfile(
+        """
+        import socket
+        import pytest
+
+        @pytest.mark.enable_socket
+        def test_socket():
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        def test_socket_disabled():
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        """
+    )
+    result = testdir.runpytest("--disable-socket")
+    assert_socket_blocked(result, passed=1, failed=1)
+
+
+def test_enable_marker_for_test_class(testdir):
+    testdir.makepyfile(
+        """
+        import socket
+        import pytest
+
+        @pytest.mark.enable_socket
+        class TestSocket:
+            def test_socket(self):
+                socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        def test_socket_disabled():
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        """
+    )
+    result = testdir.runpytest("--disable-socket")
+    assert_socket_blocked(result, passed=1, failed=1)
+
+
+def test_enable_unix_socket_via_cli_flag(testdir):
+    testdir.makepyfile(
+        """
+        import socket
+
+        def test_unix_socket():
+            socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+
+        def test_socket_disabled():
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        """
+    )
+    result = testdir.runpytest("--disable-socket", "--allow-unix-socket")
+    assert_socket_blocked(result, passed=1, failed=1)
+
+
+def test_global_disable_and_allow_host(testdir, httpbin):
+    """Disable socket globally, but allow a specific host"""
+    testdir.makepyfile(
+        f"""
+        from urllib.request import urlopen
+
+        def test_urlopen():
+            assert urlopen("{httpbin.url}/")
+
+        def test_urlopen_disabled():
+            assert urlopen("https://google.com/")
+        """
+    )
+    result = testdir.runpytest("--disable-socket", f"--allow-hosts={httpbin.host}")
+    assert_socket_blocked(result, passed=1, failed=1)

--- a/tests/test_precedence.py
+++ b/tests/test_precedence.py
@@ -1,6 +1,5 @@
 """Test module to express precedence tests between the different
 configuration combinations"""
-import pytest
 
 
 def assert_socket_blocked(result, passed=0, skipped=0, failed=1):
@@ -124,22 +123,6 @@ def test_enable_marker_for_test_class(testdir):
         """
     )
     result = testdir.runpytest("--disable-socket")
-    assert_socket_blocked(result, passed=1, failed=1)
-
-
-def test_enable_unix_socket_via_cli_flag(testdir):
-    testdir.makepyfile(
-        """
-        import socket
-
-        def test_unix_socket():
-            socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-
-        def test_socket_disabled():
-            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        """
-    )
-    result = testdir.runpytest("--disable-socket", "--allow-unix-socket")
     assert_socket_blocked(result, passed=1, failed=1)
 
 


### PR DESCRIPTION
When the plugin started out, I didn't know how to use the
`runtest_setup` phase, so I used an automatically-used fixture.
I've now removed the fixture, which may have had unintended side effects with other plugins or test suites.

I've also changed the ordering, to be more inline with the expected behaviors, as I laid out in https://github.com/miketheman/pytest-socket/discussions/81#discussion-3670981 

I've added a bunch of tests that express the desired precedence behavior in a test module `tests/test_precedence.py` and all the existing tests pass as well 🎉 .

This, and a few other bits, should lead to an 0.50.0 release.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>