### PR TITLE
chore: remove post-yield behaviors

### DIFF
--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -65,7 +65,6 @@ def socket_disabled(pytestconfig):
     """ disable socket.socket for duration of this test function """
     disable_socket(allow_unix_socket=pytestconfig.__socket_allow_unix_socket)
     yield
-    enable_socket()
 
 
 @pytest.fixture
@@ -73,7 +72,6 @@ def socket_enabled(pytestconfig):
     """ enable socket.socket for duration of this test function """
     enable_socket()
     yield
-    disable_socket(allow_unix_socket=pytestconfig.__socket_allow_unix_socket)
 
 
 def disable_socket(allow_unix_socket=False):

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -124,7 +124,7 @@ def pytest_runtest_setup(item):
 
 
 def pytest_runtest_teardown():
-    remove_host_restrictions()
+    _remove_restrictions()
 
 
 def host_from_address(address):
@@ -157,7 +157,8 @@ def socket_allow_hosts(allowed=None):
     socket.socket.connect = guarded_connect
 
 
-def remove_host_restrictions():
-    """ restore socket.socket.connect() to allow access to the Internet. useful in testing.
+def _remove_restrictions():
+    """ restore socket.socket.* to allow access to the Internet. useful in testing.
     """
+    socket.socket = _true_socket
     socket.socket.connect = _true_connect


### PR DESCRIPTION
These actions can conflict with other tests within scope,
and should already be covered by `pytest_runtest_teardown()`.

Make teardown a private function, since it's not meant to be used outside this plugin.
Add resetting the socket back to normal as well.
