### PR TITLE
fix: test allow_hosts for unix sockets

### DIFF
--- a/tests/test_combinations.py
+++ b/tests/test_combinations.py
@@ -1,4 +1,6 @@
 """Test module to express odd combinations of configurations."""
+# TODO: Move this to a more common location, like `conftest.py`.
+from test_async import unix_sockets_only
 
 
 def test_parametrize_with_socket_enabled_and_allow_hosts(testdir, httpbin):
@@ -47,6 +49,7 @@ def test_parametrize_with_socket_enabled_and_allow_hosts(testdir, httpbin):
     )
 
 
+@unix_sockets_only
 def test_combine_unix_and_allow_hosts(testdir, httpbin):
     """Test combination of disable, allow-unix and allow-hosts.
 


### PR DESCRIPTION
When combining configuration parameters, a UNIX socket was being
guarded, despite being allowed via config, since the allow-hosts config
was passed.

Resolves #78