### PR TITLE
test: move unix decorator to conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,12 @@
+import socket
+
 import pytest
-from pytest_socket import enable_socket
+
 
 pytest_plugins = 'pytester'
 
 
-@pytest.fixture(autouse=True)
-def reenable_socket():
-    """
-    The tests can leave the socket disabled in the global scope.
-    Fix by automatically re-enabling it after each test.
-    """
-    yield
-    enable_socket()
+unix_sockets_only = pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"),
+    reason="Skip any platform that does not support AF_UNIX",
+)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,12 +1,5 @@
-import socket
-
-import pytest
+from conftest import unix_sockets_only
 from test_socket import assert_socket_blocked
-
-unix_sockets_only = pytest.mark.skipif(
-    not hasattr(socket, "AF_UNIX"),
-    reason="Skip any platform that does not support AF_UNIX",
-)
 
 
 @unix_sockets_only

--- a/tests/test_combinations.py
+++ b/tests/test_combinations.py
@@ -1,6 +1,5 @@
 """Test module to express odd combinations of configurations."""
-# TODO: Move this to a more common location, like `conftest.py`.
-from test_async import unix_sockets_only
+from conftest import unix_sockets_only
 
 
 def test_parametrize_with_socket_enabled_and_allow_hosts(testdir, httpbin):

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
-import socket
+
+from conftest import unix_sockets_only
 
 
 PYFILE_SOCKET_USED_IN_TEST_ARGS = """
@@ -261,7 +262,7 @@ def test_socket_subclass_is_still_blocked(testdir):
     assert_socket_blocked(result)
 
 
-@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Skip any platform that does not support AF_UNIX")
+@unix_sockets_only
 def test_unix_domain_sockets_blocked_with_disable_socket(testdir):
     testdir.makepyfile("""
         import socket
@@ -273,7 +274,7 @@ def test_unix_domain_sockets_blocked_with_disable_socket(testdir):
     assert_socket_blocked(result)
 
 
-@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Skip any platform that does not support AF_UNIX")
+@unix_sockets_only
 def test_enabling_unix_domain_sockets_with_disable_socket(testdir):
     testdir.makepyfile("""
         import socket


### PR DESCRIPTION
Instead of implementing and importing the same feature across modules,
put it somewhere common.

The removals are for a behavior that is no longer needed now that the
teardown phase cleans up after itself.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>