### PR TITLE
test: replace coverage command

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Prepare project for development
       run: poetry install
     - name: Test with pytest
-      run: poetry run pytest
+      run: poetry run coverage run -m pytest ; coverage report --show-missing

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 	@touch $(INSTALL_STAMP)
 
 test: $(INSTALL_STAMP)
-	@poetry run pytest $(PYTEST_FLAGS)
+	@poetry run coverage run -m pytest $(PYTEST_FLAGS) ; coverage report --show-missing
 
 dist: clean $(INSTALL_STAMP)
 	@poetry build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ readme = "README.md"
 homepage = "https://pypi.org/project/pytest-socket/"
 repository = "https://github.com/miketheman/pytest-socket"
 include = [
-    "LICENSE",
-    "README.md",
+    { path = "LICENSE" },
+    { path = "README.md" },
     { path = "tests", format = "sdist" },
     { path = "pytest.ini", format = "sdist" },
     { path = ".coveragerc", format = "sdist" },
@@ -35,8 +35,8 @@ python = "^3.7"
 pytest = ">=3.6.3"
 
 [tool.poetry.dev-dependencies]
+coverage = "^6.2"
 pytest = "^6.0"
-pytest-cov = "^2.8.1"
 pytest-httpbin = "^1.0"
 pytest-randomly = "^3.5.0"
 asynctest = "^0.13.0"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-addopts =
-    --cov
-    --cov-report=term


### PR DESCRIPTION
Using pytest-cov wasn't conducive to testing pytest **plugins**.

Replace the plugin with command line invocation.

The `pyproject.toml` syntax needed to be updated to have all entries in
the `include` list to be the same type of object, thanks to to the
`toml` library.

Resolves #58

Signed-off-by: Mike Fiedler <miketheman@gmail.com>