### PR TITLE
refactor: replace .format with f-strings

### DIFF
--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -17,7 +17,7 @@ class SocketConnectBlockedError(RuntimeError):
         if allowed:
             allowed = ','.join(allowed)
         super(SocketConnectBlockedError, self).__init__(
-            'A test tried to use socket.socket.connect() with host "{0}" (allowed: "{1}").'.format(host, allowed)
+            f'A test tried to use socket.socket.connect() with host "{host}" (allowed: "{allowed}").'
         )
 
 


### PR DESCRIPTION
We no longer support Python 2.7, or anything below Python 3.6.
We can now safely use f-strings and terser syntax.

**refactor**: remove unnecessary parsing 

The `httpbin` fixture gives us both `host` and `port` attributes, so we
can use them directly instead of parsing a constructed URL from the same
parts.