### PR TITLE
Support non-function test items in pytest_runtest_setup

### DIFF
--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -113,6 +113,11 @@ def pytest_runtest_setup(item) -> None:
     As the logic can be extensive, this method is allowed complexity.
     It may be refactored in the future to be more readable.
     """
+       
+    # If the given item is not a function test (i.e a DoctestItem) or otherwise 
+    # has no support for fixtures, skip
+    if not hasattr(item, "fixturenames"):
+        return
 
     # If test has the `enable_socket` marker, we accept this as most explicit.
     if "socket_enabled" in item.fixturenames or item.get_closest_marker(

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -113,8 +113,8 @@ def pytest_runtest_setup(item) -> None:
     As the logic can be extensive, this method is allowed complexity.
     It may be refactored in the future to be more readable.
     """
-       
-    # If the given item is not a function test (i.e a DoctestItem) or otherwise 
+
+    # If the given item is not a function test (i.e a DoctestItem) or otherwise
     # has no support for fixtures, skip
     if not hasattr(item, "fixturenames"):
         return


### PR DESCRIPTION
https://github.com/pytest-dev/pytest/issues/5070 for more information

If you run pytest with `--doctest-modules` this will cause the following exception to be raised:

```
item = <DoctestItem foo.bar>
    def pytest_runtest_setup(item) -> None:
        """During each test item's setup phase,
        choose the behavior based on the configurations supplied.
    
        This is the bulk of the logic for the plugin.
        As the logic can be extensive, this method is allowed complexity.
        It may be refactored in the future to be more readable.
        """
    
        # If test has the `enable_socket` marker, we accept this as most explicit.
>       if "socket_enabled" in item.fixturenames or item.get_closest_marker(
            "enable_socket"
        ):
E       AttributeError: 'DoctestItem' object has no attribute 'fixturenames'
```

Also thank you for the great library 🙏 