### PR TITLE
fix: don't break on doctests

### DIFF
--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -112,7 +112,12 @@ def pytest_runtest_setup(item) -> None:
     This is the bulk of the logic for the plugin.
     As the logic can be extensive, this method is allowed complexity.
     It may be refactored in the future to be more readable.
+
+    If the given item is not a function test (i.e a DoctestItem)
+    or otherwise has no support for fixtures, skip it.
     """
+    if not hasattr(item, "fixturenames"):
+        return
 
     # If test has the `enable_socket` marker, we accept this as most explicit.
     if "socket_enabled" in item.fixturenames or item.get_closest_marker(

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -1,4 +1,3 @@
-
 def test_function_with_doctest(testdir):
     testdir.makepyfile(
         '''

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -1,0 +1,15 @@
+
+def test_function_with_doctest(testdir):
+    testdir.makepyfile(
+        '''
+        def my_sum(a, b):
+            """Sum two values.
+
+            >>> my_sum(1, 1)
+            2
+            """
+            return a + b
+        '''
+    )
+    result = testdir.runpytest("--doctest-modules")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
Fix AttributeError: 'DoctestItem' object has no attribute 'fixturenames'.

Fix #105.

I am piggybacking on @orf's pull request and adding a test to it: #107

Thank you both!