### PR TITLE
chore: update make target to handle installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ clean:
 	@rm -fr $(INSTALL_STAMP) .cache/ .coverage .pytest_cache/ *.egg-info/ dist/ htmlcov/
 
 install: $(INSTALL_STAMP)
+poetry.lock:
 $(INSTALL_STAMP): pyproject.toml poetry.lock
 ifndef POETRY
 	$(error "poetry is not available, please install it first.")


### PR DESCRIPTION
The `make install` target has evolved a bit, and now if a new project
checks out the code and runs `make`, we should expect that the
dependencies get installed and the tests run.

Of course, this is predicated on the existence of `poetry`, which is
already handled.

Fixes #60

Signed-off-by: Mike Fiedler <miketheman@gmail.com>