### PR TITLE
fix(deps): pin httpbin to a fixed version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,6 @@ repos:
     -   id: isort
         name: isort (python)
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     -   id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ asynctest = "^0.13.0"
 requests = "^2.26.0"
 starlette = "^0.19.0"
 httpx = "^0.22.0"
+# See https://github.com/postmanlabs/httpbin/pull/674
+httpbin = { git = "https://github.com/maximino-dev/httpbin.git", rev = "5cc81ce87" }
 
 [tool.poetry.plugins.pytest11]
 socket = 'pytest_socket'


### PR DESCRIPTION
With a werkzeug update, tests being to fail, as httpbin has not updated
their dependencies and import paths to match.

Include a specific revision of a fix.

Consider a future change replacing `httpbin` with something that has
more support, as `httpbin` appears to be unmaintained.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>