### PR TITLE
chore: update for modern python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,8 @@ repos:
     rev: 22.3.0
     hooks:
     -   id: black
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.34.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py37-plus]

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import socket
 
 import pytest
@@ -9,14 +8,14 @@ _true_connect = socket.socket.connect
 
 class SocketBlockedError(RuntimeError):
     def __init__(self, *args, **kwargs):
-        super(SocketBlockedError, self).__init__("A test tried to use socket.socket.")
+        super().__init__("A test tried to use socket.socket.")
 
 
 class SocketConnectBlockedError(RuntimeError):
     def __init__(self, allowed, host, *args, **kwargs):
         if allowed:
             allowed = ",".join(allowed)
-        super(SocketConnectBlockedError, self).__init__(
+        super().__init__(
             "A test tried to use socket.socket.connect() "
             f'with host "{host}" (allowed: "{allowed}").'
         )

--- a/tests/test_restrict_hosts.py
+++ b/tests/test_restrict_hosts.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import inspect
 
 import pytest

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 from conftest import unix_sockets_only


### PR DESCRIPTION
We support Python 3.7 and above for now, so we can remove older
artifacts that are no longer necessary in this version and above.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>