### PR TITLE
chore: remove trailing whitespace

### DIFF
--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -57,7 +57,7 @@ jobs:
       # We need the rust toolchain because it uses rustc and cargo to inspect the package
       - name: Configure Rust 1.x stable
         uses: actions-rs/toolchain@v1
-        if: ${{ fromJSON(steps.detect-languages.outputs.languages).rust }} 
+        if: ${{ fromJSON(steps.detect-languages.outputs.languages).rust }}
         with:
           toolchain: stable
 


### PR DESCRIPTION
Was introduced with CodeSee, broke pre-commit checks after that.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>