### PR TITLE
test: correct execution runner for coverage report

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Prepare project for development
       run: poetry install
     - name: Test with pytest
-      run: poetry run coverage run -m pytest ; coverage report --show-missing
+      run: poetry run coverage run -m pytest ; poetry run coverage report --show-missing

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 	@touch $(INSTALL_STAMP)
 
 test: $(INSTALL_STAMP)
-	@poetry run coverage run -m pytest $(PYTEST_FLAGS) ; coverage report --show-missing
+	@poetry run coverage run -m pytest $(PYTEST_FLAGS) ; poetry run coverage report --show-missing
 
 dist: clean $(INSTALL_STAMP)
 	@poetry build


### PR DESCRIPTION
Prior refactoring to use `poetry` for dependency management, the `coverage` command was executed directly. This was changed to use `poetry run` to ensure the correct version of `coverage` was used.

However, the `coverage report` command was not updated to use `poetry run` and thus was not using the correct version of `coverage`.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>