### PR TITLE
feat: force enable socket CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ def pytest_runtest_setup():
 ```
 
 If you exceptionally want to enable socket for one particular execution
-pass `--force-enable-socket`. It takes precedence over `--disable-socket`. 
+pass `--force-enable-socket`. It takes precedence over `--disable-socket`.
 
 To enable Unix sockets during the test run (e.g. for async), add this option:
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ def pytest_runtest_setup():
     disable_socket()
 ```
 
+If you exceptionally want to enable socket for one particular execution
+pass `--force-enable-socket`. It takes precedence over `--disable-socket`. 
+
 To enable Unix sockets during the test run (e.g. for async), add this option:
 
 ```ini
@@ -100,6 +103,7 @@ or for whole test run
 [pytest]
 addopts = --allow-hosts=127.0.0.1,127.0.1.1
 ```
+
 
 ### Frequently Asked Questions
 

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -126,8 +126,8 @@ def pytest_runtest_setup(item) -> None:
     if not hasattr(item, "fixturenames"):
         return
 
-    # If test has the `enable_socket` marker, fixture or cli,
-    # we accept this as most explicit.
+    # If test has the `enable_socket` marker, fixture or
+    # it's forced from the CLI, we accept this as most explicit.
     if (
         "socket_enabled" in item.fixturenames
         or item.get_closest_marker("enable_socket")

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -31,6 +31,12 @@ def pytest_addoption(parser):
         help="Disable socket.socket by default to block network calls.",
     )
     group.addoption(
+        "--force-enable-socket",
+        action="store_true",
+        dest="force_enable_socket",
+        help="Force enable socket.socket network calls (override --disable-socket).",
+    )
+    group.addoption(
         "--allow-hosts",
         dest="allow_hosts",
         metavar="ALLOWED_HOSTS_CSV",
@@ -100,6 +106,7 @@ def pytest_configure(config):
     )
 
     # Store the global configs in the `pytest.Config` object.
+    config.__socket_force_enabled = config.getoption("--force-enable-socket")
     config.__socket_disabled = config.getoption("--disable-socket")
     config.__socket_allow_unix_socket = config.getoption("--allow-unix-socket")
     config.__socket_allow_hosts = config.getoption("--allow-hosts")
@@ -119,9 +126,12 @@ def pytest_runtest_setup(item) -> None:
     if not hasattr(item, "fixturenames"):
         return
 
-    # If test has the `enable_socket` marker, we accept this as most explicit.
-    if "socket_enabled" in item.fixturenames or item.get_closest_marker(
-        "enable_socket"
+    # If test has the `enable_socket` marker, fixture or cli,
+    # we accept this as most explicit.
+    if (
+        "socket_enabled" in item.fixturenames
+        or item.get_closest_marker("enable_socket")
+        or item.config.__socket_force_enabled
     ):
         enable_socket()
         return

--- a/tests/test_precedence.py
+++ b/tests/test_precedence.py
@@ -54,6 +54,34 @@ def test_global_disable_via_cli_flag(testdir):
     assert_socket_blocked(result)
 
 
+def test_force_enable_socket_via_cli_flag(testdir):
+    testdir.makepyfile(
+        """
+        import socket
+        import pytest
+
+        @pytest.mark.disable_socket
+        def test_socket():
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        """
+    )
+    result = testdir.runpytest("--force-enable-socket")
+    result.assert_outcomes(passed=1)
+
+
+def test_force_enable_cli_flag_precedence(testdir):
+    testdir.makepyfile(
+        """
+        import socket
+
+        def test_socket():
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        """
+    )
+    result = testdir.runpytest("--disable-socket", "--force-enable-socket")
+    result.assert_outcomes(passed=1)
+
+
 def test_global_disable_via_config(testdir):
     testdir.makepyfile(
         """


### PR DESCRIPTION
I need to have sockets disabled by default in pyproject.yml but still be able to override it from the command line. 

so `pytest --force-enable-socket` takes precedence even when pyproject.yml has

```
addopts = "--disable-socket"
```
