### PR TITLE
feat(allow_hosts): add support for hostname resolution

### DIFF
--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -213,8 +213,9 @@ def socket_allow_hosts(allowed=None, allow_unix_socket=False):
 
     def guarded_connect(inst, *args):
         host = host_from_connect_args(args)
-        if host in allowed_hosts or \
-                (_is_unix_socket(inst.family) and allow_unix_socket):
+        if host in allowed_hosts or (
+            _is_unix_socket(inst.family) and allow_unix_socket
+        ):
             return _true_connect(inst, *args)
 
         raise SocketConnectBlockedError(allowed, host)

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -213,7 +213,8 @@ def socket_allow_hosts(allowed=None, allow_unix_socket=False):
 
     def guarded_connect(inst, *args):
         host = host_from_connect_args(args)
-        if host in allowed_hosts or (_is_unix_socket(inst.family) and allow_unix_socket):
+        if host in allowed_hosts or \
+                (_is_unix_socket(inst.family) and allow_unix_socket):
             return _true_connect(inst, *args)
 
         raise SocketConnectBlockedError(allowed, host)

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -1,3 +1,4 @@
+import ipaddress
 import socket
 
 import pytest
@@ -172,12 +173,12 @@ def host_from_connect_args(args):
 
 def is_ipaddress(address: str):
     """
-    Determine if the address is a valid IPv4 address.
+    Determine if the address is a valid IPv4 or IPv6 address.
     """
     try:
-        socket.inet_aton(address)
+        ipaddress.ip_address(address)
         return True
-    except OSError:
+    except ValueError:
         return False
 
 

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -177,7 +177,7 @@ def is_ipaddress(address: str):
     try:
         socket.inet_aton(address)
         return True
-    except socket.error:
+    except OSError:
         return False
 
 

--- a/tests/test_restrict_hosts.py
+++ b/tests/test_restrict_hosts.py
@@ -106,6 +106,14 @@ def test_single_cli_arg_connect_enabled(assert_connect):
     assert_connect(True, cli_arg=localhost)
 
 
+def test_single_cli_arg_connect_enabled_hostname_resolved(assert_connect):
+    assert_connect(True, cli_arg="localhost")
+
+
+def test_single_cli_arg_connect_enabled_hostname_unresolvable(assert_connect):
+    assert_connect(False, cli_arg="unresolvable")
+
+
 def test_single_cli_arg_connect_unicode_enabled(assert_connect):
     assert_connect(True, cli_arg=localhost, code_template=connect_unicode_code_template)
 


### PR DESCRIPTION
This is equivalent to #80 but brought up to date with `main`. This is necessary when using `docker-compose` to avoid having to assign static IPs to specific services.