### PR TITLE
fix: Fix resolving named hosts.

### DIFF
--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -226,6 +226,8 @@ def socket_allow_hosts(allowed=None, allow_unix_socket=False):
 
     def guarded_connect(inst, *args):
         host = host_from_connect_args(args)
+        if host and not is_ipaddress(host):
+            host = resolve_hostname(host)
         if host in allowed_hosts or (
             _is_unix_socket(inst.family) and allow_unix_socket
         ):


### PR DESCRIPTION
Version 0.6 broke our testing pipelines, because it "upgraded" hostnames to IP addresses, but didn't also upgrade the hostname passed in via arguments. This patch resolves this by also resolving hostnames passed in via arguments.