### PR TITLE
fix: only emit license and readme for sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ readme = "README.md"
 homepage = "https://pypi.org/project/pytest-socket/"
 repository = "https://github.com/miketheman/pytest-socket"
 include = [
-    { path = "LICENSE" },
-    { path = "README.md" },
+    { path = "LICENSE", format = "sdist" },
+    { path = "README.md", format = "sdist" },
     { path = "tests", format = "sdist" },
     { path = ".flake8", format = "sdist" },
 ]


### PR DESCRIPTION
As the file contents are already being included in the wheel's `dist-info` folder either alone or embedded into PKG-INFO, we don't need to emit these ourselves.

Resolves #230