### PR TITLE
Add testing against the Python 3.13 beta release

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,7 +19,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4.1.7
@@ -30,6 +30,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'poetry'
+        allow-prereleases: true
     - name: Prepare project for development
       run: poetry install
     - name: Test with pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Add testing against the Python 3.13 beta release.

- **.github/workflows/python.yml**
  - Add `3.13` to the `python-version` matrix.
  - Add `allow-prereleases: true` to the `with` section of `actions/setup-python@v5`.

- **pyproject.toml**
  - Add `3.13` to the `classifiers` section under `Programming Language :: Python`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/miketheman/pytest-socket?shareId=f77da5dc-fb61-484e-a5fd-db0cd17b1dab).