### PR TITLE
Cache name resolutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ tests to ensure network calls are prevented.
 
 ## Requirements
 
-- [Pytest](https://github.com/pytest-dev/pytest) 6.2.5 or greater
+- [Pytest](https://github.com/pytest-dev/pytest) 7.0 or greater
 
 ## Installation
 
@@ -43,21 +43,21 @@ Run `pytest --disable-socket`, tests should fail on any access to `socket` or
 libraries using socket with a `SocketBlockedError`.
 
 To add this flag as the default behavior, add this section to your
-[`pytest.ini`](https://docs.pytest.org/en/6.2.x/customize.html#pytest-ini):
+[`pytest.ini`](https://docs.pytest.org/en/stable/reference/customize.html#pytest-ini):
 
 ```ini
 [pytest]
 addopts = --disable-socket
 ```
 
-or add this to your [`setup.cfg`](https://docs.pytest.org/en/6.2.x/customize.html#setup-cfg):
+or add this to your [`setup.cfg`](https://docs.pytest.org/en/stable/reference/customize.html#setup-cfg):
 
 ```ini
 [tool:pytest]
 addopts = --disable-socket
 ```
 
-or update your [`conftest.py`](https://docs.pytest.org/en/6.2.x/writing_plugins.html#conftest-py-plugins) to include:
+or update your [`conftest.py`](https://docs.pytest.org/en/stable/how-to/writing_plugins.html#conftest-py-local-per-directory-plugins) to include:
 
 ```python
 from pytest_socket import disable_socket

--- a/poetry.lock
+++ b/poetry.lock
@@ -1300,4 +1300,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "d54786b029b9e44b9ce0a569b59e33d669f5b803fe6cb9431d144662fb118327"
+content-hash = "adb8e3ec44ecc0f22c3edb8d289934bda4bd5988ec97acc2a981b57db86cd1a6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pytest = ">=6.2.5"
+pytest = ">=7.0.0"
 
 [tool.poetry.dev-dependencies]
 coverage = "^7.6"

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -262,7 +262,7 @@ def socket_allow_hosts(
     if not isinstance(allowed, list):
         return
 
-    allowed_ip_hosts_by_host = normalize_allowed_hosts(allowed)
+    allowed_ip_hosts_by_host = normalize_allowed_hosts(allowed, resolution_cache)
     allowed_ip_hosts_and_hostnames = set(
         itertools.chain(*allowed_ip_hosts_by_host.values())
     ) | set(allowed_ip_hosts_by_host.keys())

--- a/pytest_socket.py
+++ b/pytest_socket.py
@@ -3,7 +3,7 @@ import itertools
 import socket
 import typing
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import pytest
 
@@ -75,7 +75,7 @@ class _PytestSocketConfig:
     socket_force_enabled: bool
     allow_unix_socket: bool
     allow_hosts: typing.Union[str, typing.List[str], None]
-    resolution_cache: typing.Dict[str, typing.Set[str]]
+    resolution_cache: typing.Dict[str, typing.Set[str]] = field(default_factory=dict)
 
 
 _STASH_KEY = pytest.StashKey[_PytestSocketConfig]()
@@ -128,7 +128,6 @@ def pytest_configure(config):
         socket_disabled=config.getoption("--disable-socket"),
         allow_unix_socket=config.getoption("--allow-unix-socket"),
         allow_hosts=config.getoption("--allow-hosts"),
-        resolution_cache={},
     )
 
 


### PR DESCRIPTION
To avoid resolving the allowed hostnames once per test, cache the results in a shared dict. This should result in one set of resolutions per pytest run (or test worker, under pytest-xdist). I did this in a backward-compatible manner by introducing an optional parameter to the `socket_allow_hosts()` and `normalize_allowed_hosts()` functions as they appear to be public API, albeit undocumented.

I also refactored the plugin [to use Stash](https://docs.pytest.org/en/7.0.x/how-to/writing_hook_functions.html#plugin-stash), which was introduced in pytest 7.0.0, rather than set attributes on Config. If you want to keep support for `pytest>=6.2.5` I can back that bit out, I just thought it improved clarity.
