### PR TITLE
test: update real endpoint in test

### DIFF
--- a/tests/test_combinations.py
+++ b/tests/test_combinations.py
@@ -23,7 +23,7 @@ def test_parametrize_with_socket_enabled_and_allow_hosts(testdir, httpbin):
             [
                 "https://google.com",
                 "https://amazon.com",
-                "https://microsoft.com",
+                "https://www.microsoft.com",
             ],
         )
         def test_domain(url, socket_enabled):


### PR DESCRIPTION
When not using the `www` prefix SSL negotiation can take 60+ seconds locally, which is annoying and slow.