### PR TITLE
Change exception base class to BaseException for socket errors

### DIFF
--- a/src/pytest_socket/__init__.py
+++ b/src/pytest_socket/__init__.py
@@ -11,12 +11,12 @@ _true_socket = socket.socket
 _true_connect = socket.socket.connect
 
 
-class SocketBlockedError(RuntimeError):
+class SocketBlockedError(BaseException):
     def __init__(self, *_args, **_kwargs):
         super().__init__("A test tried to use socket.socket.")
 
 
-class SocketConnectBlockedError(RuntimeError):
+class SocketConnectBlockedError(BaseException):
     def __init__(self, allowed, host, *_args, **_kwargs):
         if allowed:
             allowed = ",".join(allowed)


### PR DESCRIPTION
Change exception base class to `BaseException` for socket errors

The change is intended to fail tests which otherwise pass because there's code catching and logging unexpected `Exception`.
Ideally, we should be able to fail tests without relying on exceptions bubbling up to pytest, but I'm not sure how to achieve that?