### PR TITLE
feat(allow_hosts): support CIDR network entries

### DIFF
--- a/src/pytest_socket/__init__.py
+++ b/src/pytest_socket/__init__.py
@@ -14,6 +14,8 @@ import pytest
 _true_socket = socket.socket
 _true_connect = socket.socket.connect
 
+_IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
 
 class SocketBlockedError(RuntimeError):
     def __init__(self, *_args: Any, **_kwargs: Any) -> None:
@@ -266,6 +268,29 @@ def normalize_allowed_hosts(
     return ip_hosts
 
 
+def _partition_allowed(
+    allowed: list[str],
+) -> tuple[list[str], list[_IPNetwork]]:
+    """Split an allow-list into plain hosts and CIDR networks.
+
+    Entries containing ``/`` are parsed as networks. Invalid CIDR entries
+    fall through to the plain-host path so an existing test failure mode
+    (block + meaningful error) is preserved.
+    """
+    plain_hosts: list[str] = []
+    networks: list[_IPNetwork] = []
+    for entry in allowed:
+        candidate = entry.strip()
+        if "/" in candidate:
+            try:
+                networks.append(ipaddress.ip_network(candidate, strict=False))
+                continue
+            except ValueError:
+                pass
+        plain_hosts.append(candidate)
+    return plain_hosts, networks
+
+
 def socket_allow_hosts(
     allowed: str | list[str] | None = None,
     allow_unix_socket: bool = False,
@@ -278,7 +303,9 @@ def socket_allow_hosts(
     if not isinstance(allowed, list):
         return
 
-    allowed_ip_hosts_by_host = normalize_allowed_hosts(allowed, resolution_cache)
+    plain_hosts, networks = _partition_allowed(allowed)
+
+    allowed_ip_hosts_by_host = normalize_allowed_hosts(plain_hosts, resolution_cache)
     allowed_ip_hosts_and_hostnames = set(
         itertools.chain(*allowed_ip_hosts_by_host.values())
     ) | set(allowed_ip_hosts_by_host.keys())
@@ -291,6 +318,7 @@ def socket_allow_hosts(
             )
             for host, normalized in allowed_ip_hosts_by_host.items()
         ]
+        + [str(net) for net in networks]
     )
 
     def guarded_connect(inst: socket.socket, *args: Any) -> None:
@@ -299,6 +327,11 @@ def socket_allow_hosts(
             _is_unix_socket(inst.family) and allow_unix_socket
         ):
             return _true_connect(inst, *args)
+
+        if host and networks and is_ipaddress(host):
+            ip = ipaddress.ip_address(host)
+            if any(ip in net for net in networks):
+                return _true_connect(inst, *args)
 
         raise SocketConnectBlockedError(allowed_list, host)
 

--- a/tests/test_restrict_hosts.py
+++ b/tests/test_restrict_hosts.py
@@ -341,6 +341,148 @@ def test_normalize_allowed_hosts_cache(getaddrinfo_hosts):
     assert getaddrinfo_hosts == []
 
 
+def test_cidr_marker_permits_in_block_ip(pytester, httpserver):
+    """A test marked with a CIDR can connect to any IP inside that block."""
+    pytester.makepyfile(f"""
+        import pytest
+        import socket
+
+        @pytest.mark.allow_hosts('127.0.0.0/8')
+        def test_in_block():
+            socket.socket().connect(('{httpserver.host}', {httpserver.port}))
+        """)
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_cidr_marker_blocks_out_of_block_ip(pytester, httpserver):
+    """A CIDR marker still blocks IPs outside the block."""
+    pytester.makepyfile(f"""
+        import pytest
+        import socket
+
+        @pytest.mark.allow_hosts('127.0.0.0/8')
+        def test_out_of_block():
+            socket.socket().connect(('2.2.2.2', {httpserver.port}))
+        """)
+    result = pytester.runpytest()
+    result.assert_outcomes(failed=1)
+    assert_host_blocked(result, "2.2.2.2")
+
+
+def test_cidr_via_cli_flag(pytester, httpserver):
+    """CIDR works the same when passed via --allow-hosts CSV."""
+    pytester.makepyfile(f"""
+        import socket
+
+        def test_in_block():
+            socket.socket().connect(('{httpserver.host}', {httpserver.port}))
+
+        def test_out_of_block():
+            socket.socket().connect(('2.2.2.2', {httpserver.port}))
+        """)
+    result = pytester.runpytest("--allow-hosts=127.0.0.0/8")
+    result.assert_outcomes(passed=1, failed=1)
+    assert_host_blocked(result, "2.2.2.2")
+
+
+def test_mixed_cidr_ip_and_hostname_allowlist(pytester, httpserver):
+    """CIDR and literal-IP entries coexist in one allowlist.
+
+    Hostname coexistence is exercised by ``test_normalize_allowed_hosts`` and
+    ``test_name_resolution_cached``; this test focuses on the new CIDR path
+    sharing the allowlist with a literal IP (the live ``httpserver``) and
+    confirms that an unrelated host is still blocked.
+    """
+    pytester.makepyfile(f"""
+        import pytest
+        import socket
+
+        @pytest.mark.allow_hosts(['10.0.0.0/8', '{httpserver.host}'])
+        def test_literal_ip_path():
+            socket.socket().connect(('{httpserver.host}', {httpserver.port}))
+
+        @pytest.mark.allow_hosts(['10.0.0.0/8', '{httpserver.host}'])
+        def test_cidr_path_blocks_outsider():
+            socket.socket().connect(('2.2.2.2', {httpserver.port}))
+        """)
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1, failed=1)
+    assert_host_blocked(result, "2.2.2.2")
+
+
+def test_ipv6_cidr(pytester):
+    """IPv6 CIDR allow-list permits in-block addresses and blocks others."""
+    pytester.makepyfile("""
+        import pytest
+        import socket
+
+        @pytest.mark.allow_hosts('::1/128')
+        def test_in_block():
+            # ::1 is in the /128 block — guard should permit; real connect
+            # may still error at the OS level, but not as SocketConnectBlockedError.
+            try:
+                socket.socket(socket.AF_INET6).connect(('::1', 1))
+            except OSError as exc:
+                # Anything except SocketConnectBlockedError is fine here.
+                import pytest_socket
+                assert not isinstance(exc, pytest_socket.SocketConnectBlockedError)
+
+        @pytest.mark.allow_hosts('::1/128')
+        def test_out_of_block():
+            socket.socket(socket.AF_INET6).connect(('2001:db8::1', 1))
+        """)
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1, failed=1)
+    assert_host_blocked(result, "2001:db8::1")
+
+
+def test_hostname_arg_with_cidr_only_allowlist(pytester):
+    """A connect call using a hostname (not an IP) under a CIDR-only allowlist
+    raises SocketConnectBlockedError — not a ValueError from ipaddress.
+
+    This is the failure mode that prevented merging the original CIDR PR (#185).
+    """
+    pytester.makepyfile("""
+        import socket
+
+        def test_hostname_connect():
+            # 'example.invalid' will never resolve to an IP; the guard must
+            # block it cleanly rather than crashing when it tries to parse
+            # the hostname as an IP for CIDR membership.
+            socket.socket().connect(('example.invalid', 80))
+        """)
+    result = pytester.runpytest("--allow-hosts=10.0.0.0/8")
+    result.assert_outcomes(failed=1)
+    assert_host_blocked(result, "example.invalid")
+
+
+def test_cidr_appears_in_blocked_error_message(pytester):
+    """The 'allowed:' hint in the blocked-connect message includes CIDR strings."""
+    pytester.makepyfile("""
+        import socket
+
+        def test_blocked():
+            socket.socket().connect(('2.2.2.2', 80))
+        """)
+    result = pytester.runpytest("--allow-hosts=10.0.0.0/8,192.168.0.0/16")
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines('*allowed: "10.0.0.0/8,192.168.0.0/16"*')
+
+
+def test_malformed_cidr_does_not_crash(pytester):
+    """A malformed CIDR entry is treated as a (non-resolving) host, not a crash."""
+    pytester.makepyfile("""
+        import socket
+
+        def test_blocked():
+            socket.socket().connect(('2.2.2.2', 80))
+        """)
+    result = pytester.runpytest("--allow-hosts=10.0.0.0/notanumber")
+    result.assert_outcomes(failed=1)
+    assert_host_blocked(result, "2.2.2.2")
+
+
 def test_name_resolution_cached(pytester, getaddrinfo_hosts):
     """pytest-socket only resolves each allowed name once."""
 


### PR DESCRIPTION
Entries containing "/" in --allow-hosts (CLI and marker) are parsed as IPv4 or IPv6 networks via ipaddress.ip_network(strict=False). Plain hosts continue through the existing hostname/IP resolution path; CIDR strings render verbatim in blocked-connect errors.

The membership check is gated on is_ipaddress(host) so a hostname-style connect arg under a CIDR-only allow-list raises SocketConnectBlockedError rather than crashing with ValueError — the failure mode that blocked #185 from merging.

Closes #185