### PR TITLE
feat: also block DNS resolution

### DIFF
--- a/src/pytest_socket/__init__.py
+++ b/src/pytest_socket/__init__.py
@@ -13,13 +13,19 @@ import pytest
 
 _true_socket = socket.socket
 _true_connect = socket.socket.connect
+_true_getaddrinfo = socket.getaddrinfo
+_true_gethostbyname = socket.gethostbyname
 
 _IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
 
 
 class SocketBlockedError(RuntimeError):
-    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
-        msg = "A test tried to use socket.socket."
+    def __init__(
+        self,
+        msg: str = "A test tried to use socket.socket.",
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> None:
         warnings.warn(msg, stacklevel=2)
         super().__init__(msg)
 
@@ -100,6 +106,14 @@ def _is_unix_socket(family: int) -> bool:
     return hasattr(socket, "AF_UNIX") and family == socket.AF_UNIX
 
 
+def _guarded_getaddrinfo(*_args: Any, **_kwargs: Any) -> Any:
+    raise SocketBlockedError("A test tried to use socket.getaddrinfo.")
+
+
+def _guarded_gethostbyname(*_args: Any, **_kwargs: Any) -> Any:
+    raise SocketBlockedError("A test tried to use socket.gethostbyname.")
+
+
 def disable_socket(allow_unix_socket: bool = False) -> None:
     """disable socket.socket to disable the Internet. useful in testing."""
 
@@ -119,11 +133,17 @@ def disable_socket(allow_unix_socket: bool = False) -> None:
             raise SocketBlockedError()
 
     socket.socket = GuardedSocket  # type: ignore[misc]
+    socket.getaddrinfo = _guarded_getaddrinfo
+    socket.gethostbyname = _guarded_gethostbyname
 
 
 def enable_socket() -> None:
     """re-enable socket.socket to enable the Internet. useful in testing."""
     socket.socket = _true_socket  # type: ignore[misc]
+    if socket.getaddrinfo is _guarded_getaddrinfo:
+        socket.getaddrinfo = _true_getaddrinfo
+    if socket.gethostbyname is _guarded_gethostbyname:
+        socket.gethostbyname = _true_gethostbyname
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -342,3 +362,7 @@ def _remove_restrictions() -> None:
     """restore socket.socket.* to allow access to the Internet. useful in testing."""
     socket.socket = _true_socket  # type: ignore[misc]
     socket.socket.connect = _true_connect  # type: ignore[method-assign]
+    if socket.getaddrinfo is _guarded_getaddrinfo:
+        socket.getaddrinfo = _true_getaddrinfo
+    if socket.gethostbyname is _guarded_gethostbyname:
+        socket.gethostbyname = _true_gethostbyname

--- a/tests/common.py
+++ b/tests/common.py
@@ -11,6 +11,4 @@ def assert_socket_blocked(result, passed=0, skipped=0, failed=1):
     so we can pass in the expected counts.
     """
     result.assert_outcomes(passed=passed, skipped=skipped, failed=failed)
-    result.stdout.fnmatch_lines(
-        "*Socket*Blocked*Error: A test tried to use socket.socket.*"
-    )
+    result.stdout.fnmatch_lines("*Socket*Blocked*Error: A test tried to use socket.*")

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -1,0 +1,122 @@
+"""Tests for the DNS-resolution guard added alongside --disable-socket."""
+
+
+def test_dns_restored_between_tests(pytester):
+    # teardown of a blocked test must restore getaddrinfo/gethostbyname so the
+    # next test sees the real functions, not a stale guard from the prior test.
+    pytester.makepyfile("""
+        import pytest
+        import socket
+
+        @pytest.mark.disable_socket
+        def test_blocked():
+            socket.gethostbyname('localhost')
+
+        @pytest.mark.enable_socket
+        def test_works_after():
+            socket.gethostbyname('localhost')
+        """)
+    result = pytester.runpytest("-p", "no:randomly")
+    result.assert_outcomes(passed=1, failed=1)
+
+
+def test_dns_unblocked_by_force_enable(pytester):
+    pytester.makepyfile("""
+        import socket
+
+        def test_dns():
+            socket.gethostbyname('localhost')
+        """)
+    result = pytester.runpytest("--disable-socket", "--force-enable-socket")
+    result.assert_outcomes(passed=1)
+
+
+def test_dns_unblocked_by_marker(pytester):
+    pytester.makepyfile("""
+        import pytest
+        import socket
+
+        @pytest.mark.enable_socket
+        def test_dns():
+            socket.gethostbyname('localhost')
+        """)
+    result = pytester.runpytest("--disable-socket")
+    result.assert_outcomes(passed=1)
+
+
+def test_allow_hosts_with_hostname_under_disable_socket(pytester, httpserver):
+    # End-to-end: `--disable-socket --allow-hosts=<hostname>` must resolve the
+    # hostname at setup and accept a connection to that name from a test.
+    pytester.makepyfile(f"""
+        import socket
+
+        def test_connect_via_allowed_hostname():
+            socket.socket().connect(('localhost', {httpserver.port}))
+        """)
+    result = pytester.runpytest("--disable-socket", "--allow-hosts=localhost")
+    result.assert_outcomes(passed=1)
+
+
+def test_error_messages_identify_the_blocked_function(pytester):
+    # Each guarded entry point names itself in the error so a failing test
+    # tells the developer which call was caught.
+    pytester.makepyfile("""
+        import socket
+
+        def test_addrinfo():
+            socket.getaddrinfo('localhost', 80)
+
+        def test_hostbyname():
+            socket.gethostbyname('localhost')
+
+        def test_socket():
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        """)
+    result = pytester.runpytest("--disable-socket", "-p", "no:randomly")
+    result.assert_outcomes(failed=3)
+    result.stdout.fnmatch_lines(
+        [
+            "*A test tried to use socket.getaddrinfo.*",
+            "*A test tried to use socket.gethostbyname.*",
+            "*A test tried to use socket.socket.*",
+        ]
+    )
+
+
+def test_dns_unblocked_by_fixture(pytester):
+    pytester.makepyfile("""
+        import socket
+
+        def test_dns(socket_enabled):
+            socket.gethostbyname('localhost')
+        """)
+    result = pytester.runpytest("--disable-socket")
+    result.assert_outcomes(passed=1)
+
+
+def test_getaddrinfo_blocked_under_disable_socket(pytester):
+    pytester.makepyfile("""
+        import socket
+
+        def test_dns():
+            socket.getaddrinfo('localhost', 80)
+        """)
+    result = pytester.runpytest("--disable-socket")
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines(
+        "*SocketBlockedError: A test tried to use socket.getaddrinfo.*"
+    )
+
+
+def test_gethostbyname_blocked_under_disable_socket(pytester):
+    pytester.makepyfile("""
+        import socket
+
+        def test_dns():
+            socket.gethostbyname('localhost')
+        """)
+    result = pytester.runpytest("--disable-socket")
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines(
+        "*SocketBlockedError: A test tried to use socket.gethostbyname.*"
+    )


### PR DESCRIPTION
`--disable-socket` (and the marker/fixture) now guards `socket.getaddrinfo` and `socket.gethostbyname` too. Before this, a test could quietly resolve a hostname with sockets blocked, so "no network" wasn't really no network.

The error names the call that got caught (`socket.socket`, `socket.getaddrinfo`, `socket.gethostbyname`) so failures point at the right one.

Restoration is identity-checked: we only swap a function back if our guard is still the one in place. The resolution-cache tests monkeypatch `socket.getaddrinfo` themselves, and without that check each inner pytester teardown would stomp the outer monkeypatch.

Closes #43. Supersedes #64.