### PR TITLE
chore(ci): remove upload from release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,22 +54,3 @@ jobs:
           path: dist/
       - name: Publish 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-
-  github-release:
-    name: Attach 📦 to the GitHub Release
-    needs: publish-to-pypi
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # to upload assets onto the release
-    steps:
-      - name: Download the distribution packages
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: dist
-          path: dist/
-      - name: Upload the distribution packages to the GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          TAG: ${{ github.event.release.tag_name }}
-        run: gh release upload "$TAG" dist/* --clobber


### PR DESCRIPTION
Now that I'm using Immutable releases, there's no way to upload an artifact post-release. Since the artifact is on PyPI and there's provenance, this is less useful.