### PR TITLE
fix: make SocketConnectBlockedError pickleable

### DIFF
--- a/src/pytest_socket/__init__.py
+++ b/src/pytest_socket/__init__.py
@@ -38,6 +38,8 @@ class SocketConnectBlockedError(RuntimeError):
         *_args: Any,
         **_kwargs: Any,
     ) -> None:
+        self._allowed = allowed
+        self._host = host
         allowed_str = ",".join(allowed)
         msg = (
             "A test tried to use socket.socket.connect() "
@@ -45,6 +47,13 @@ class SocketConnectBlockedError(RuntimeError):
         )
         warnings.warn(msg, stacklevel=2)
         super().__init__(msg)
+
+    def __reduce__(self) -> tuple[Any, tuple[Any, ...]]:
+        # Reconstruct from the original constructor args so the exception
+        # survives pickling by multiprocessing test runners (e.g. pytest-xdist,
+        # Django's `--parallel`). The default `BaseException.__reduce__` would
+        # replay `self.args` (the formatted message) and miss `host`.
+        return (self.__class__, (self._allowed, self._host))
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -1,7 +1,10 @@
+import pickle
+
 import pytest
 
 from pytest_socket import (
     SocketBlockedError,
+    SocketConnectBlockedError,
     disable_socket,
     enable_socket,
     host_from_address,
@@ -291,6 +294,25 @@ def test_blocked_connect_emits_warning(pytester, httpserver):
     result = pytester.runpytest("-W", "always::UserWarning", "--allow-hosts=1.2.3.4")
     result.assert_outcomes(passed=1)
     result.stdout.fnmatch_lines("*A test tried to use socket.socket.connect()*")
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        SocketBlockedError(),
+        SocketConnectBlockedError(["0.0.0.0", "127.0.0.1"], "192.0.80.239"),
+    ],
+)
+def test_exceptions_are_pickleable(exc):
+    """Exceptions must survive a pickle round-trip.
+
+    Multiprocessing test runners (Django's ``--parallel``, pytest-xdist)
+    serialize exceptions across process boundaries; a non-pickleable
+    exception masks the real failure with a confusing ``TypeError``.
+    """
+    restored = pickle.loads(pickle.dumps(exc))
+    assert type(restored) is type(exc)
+    assert restored.args == exc.args
 
 
 @unix_sockets_only


### PR DESCRIPTION
Multiprocessing test runners (pytest-xdist, Django's `--parallel`) serialize exceptions across process boundaries. The default `BaseException.__reduce__` replays `self.args` (the formatted message) through `__init__`, which expects `(allowed, host)` — so unpickling raised `TypeError: __init__() missing 1 required positional argument: 'host'`, masking the real failure.

Store the constructor args and define `__reduce__` so the exception reconstructs via its real `__init__`, preserving the structured API and the UserWarning. Add a regression test covering a pickle round-trip for both exception types.

Inspired by #265